### PR TITLE
use string instead of Identifier for StaticMemberExpression property

### DIFF
--- a/spec.idl
+++ b/spec.idl
@@ -344,7 +344,7 @@ interface PrefixExpression : UnaryExpression {
 };
 
 interface StaticMemberExpression : MemberExpression {
-  attribute Identifier property;
+  attribute string property;
 };
 
 interface TemplateString : PrimaryExpression {


### PR DESCRIPTION
We really only have this because SpiderMonkey did. Now all Identifiers will be grammatical Identifiers (not sometimes IdentifierName). We will still have to verify that strings in this position conform to IdentifierName, but we already had to special case Identifier for that.
