### PR TITLE
fixes #8: simplify structure of ForInStatement and ForOfStatement

### DIFF
--- a/spec.idl
+++ b/spec.idl
@@ -389,12 +389,14 @@ interface ExpressionStatement : Statement {
 };
 
 interface ForInStatement : IterationStatement {
-  attribute (VariableDeclaration or Binding) left;
+  attribute VariableDeclarationKind? kind;
+  attribute Binding left;
   attribute Expression right;
 };
 
 interface ForOfStatement : IterationStatement {
-  attribute (VariableDeclaration or Binding) left;
+  attribute VariableDeclarationKind? kind;
+  attribute Binding left;
   attribute Expression right;
 };
 


### PR DESCRIPTION
I'm not 100% sure about this one. It'd be nice to be able to reduce on `VariableDeclaration` or something. But it protects us from initialisers and multiple declarators.

Fixes #8.
