### PR TITLE
use BindingIdentifier for FunctionExpression and FunctionDeclaration names

### DIFF
--- a/spec.idl
+++ b/spec.idl
@@ -216,14 +216,14 @@ interface FunctionBody : Node {
 
 interface FunctionDeclaration : Statement {
   attribute boolean isGenerator;
-  attribute Identifier name;
+  attribute BindingIdentifier name;
   attribute FunctionBody body;
 };
 FunctionDeclaration implements Function;
 
 interface FunctionExpression : Expression {
   attribute boolean isGenerator;
-  attribute Identifier? name;
+  attribute BindingIdentifier? name;
   attribute FunctionBody body;
 };
 FunctionExpression implements Function;


### PR DESCRIPTION
This aligns with [class name](https://github.com/shapesecurity/shift-spec/blob/e7ea4d0992f013adfb24d226f615db8a3935febb/spec.idl#L138), which is a BindingIdentifier.
