### PR TITLE
Revert "move MemberExpression from Binding to AssignmentExpression"

### DIFF
--- a/spec.idl
+++ b/spec.idl
@@ -102,10 +102,10 @@ interface ExportDeclaration : Node { };
 
 // bindings
 
-typedef (ObjectBinding or ArrayBinding or BindingIdentifier) Binding;
+typedef (ObjectBinding or ArrayBinding or BindingIdentifier or MemberExpression) Binding;
 
 interface BindingWithDefault : Node {
-  attribute Binding binding;
+  attribute (ObjectBinding or ArrayBinding or BindingIdentifier) binding;
   attribute Expression init;
 };
 
@@ -300,7 +300,7 @@ interface ArrayExpression : Expression {
 
 interface AssignmentExpression : Expression {
   attribute AssignmentOperator operator;
-  attribute (Binding or MemberExpression) binding;
+  attribute Binding binding;
   attribute Expression expression;
 };
 


### PR DESCRIPTION
Reverts shapesecurity/shift-spec#51

I don't know how we missed this or don't have tests for it, but we need to allow `MemberExpression`s as `Binding`s because `[a.b] = c` is valid.
