### PR TITLE
remove FunctionBody from Script

### DIFF
--- a/index.js
+++ b/index.js
@@ -780,7 +780,8 @@ exports.default = (function() {
   Script.fields = [
     { name: "type", type: Const(TYPE_INDICATOR), value: "Script" },
     { name: "loc", type: Maybe(SourceSpan) },
-    { name: "body", type: FunctionBody },
+    { name: "directives", type: List(Directive) },
+    { name: "statements", type: List(Statement) },
   ];
 
   SpreadElement.typeName = "SpreadElement";

--- a/spec.idl
+++ b/spec.idl
@@ -475,7 +475,8 @@ interface FunctionDeclaration : Statement {
 FunctionDeclaration implements Function;
 
 interface Script : Node {
-  attribute FunctionBody body;
+  attribute Directive[] directives;
+  attribute Statement[] statements;
 };
 
 interface SpreadElement : Node {


### PR DESCRIPTION
FunctionBody was only used because it had the appropriate structure, but it shares virtually no semantics. For validation / scoping purposes, it is much more useful to do something on all FunctionBody nodes rather than all nodes with a FunctionBody except Script.
