### PR TITLE
allow BindingPattern in FormalParameters.rest

### DIFF
--- a/spec.idl
+++ b/spec.idl
@@ -478,7 +478,7 @@ interface Directive : Node {
 
 interface FormalParameters : Node {
   attribute Parameter[] items;
-  attribute BindingIdentifier? rest;
+  attribute (BindingPattern or BindingIdentifier)? rest;
 };
 
 interface FunctionBody : Node {


### PR DESCRIPTION
See https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement. Since this will be in ES2015 errata, we may need to apply this change to the `es6` branch as well.
