### PR TITLE
Proposal: Rest/Spread Properties

### DIFF
--- a/attribute-order.conf
+++ b/attribute-order.conf
@@ -56,9 +56,6 @@ init
 name
 binding
 
-[BindingRest]
-argument
-
 [BindingWithDefault]
 binding
 init
@@ -303,9 +300,11 @@ arguments
 
 [ObjectAssignmentTarget]
 properties
+rest
 
 [ObjectBinding]
 properties
+rest
 
 [ObjectExpression]
 properties

--- a/attribute-order.conf
+++ b/attribute-order.conf
@@ -56,6 +56,9 @@ init
 name
 binding
 
+[BindingRest]
+argument
+
 [BindingWithDefault]
 binding
 init

--- a/spec.idl
+++ b/spec.idl
@@ -151,7 +151,7 @@ interface ArrayBinding : Node {
 };
 
 interface ObjectBinding : Node {
-  attribute BindingProperty[] properties;
+  attribute (BindingProperty or BindingRest)[] properties;
 };
 
 interface BindingProperty : Node { };
@@ -166,6 +166,11 @@ interface BindingPropertyIdentifier : BindingProperty {
 interface BindingPropertyProperty : BindingProperty {
   attribute PropertyName name;
   attribute (Binding or BindingWithDefault) binding;
+};
+
+// `...BindingRest`
+interface BindingRest : Node {
+  attribute IdentifierExpression argument;
 };
 
 // This interface represents the case where the initializer is present in `AssignmentElement :: DestructuringAssignmentTarget Initializer_opt`.
@@ -457,7 +462,7 @@ interface NewExpression : Expression {
 interface NewTargetExpression : Expression { };
 
 interface ObjectExpression : Expression {
-  attribute ObjectProperty[] properties;
+  attribute (ObjectProperty or SpreadElement)[] properties;
 };
 
 interface UnaryExpression : Expression {

--- a/spec.idl
+++ b/spec.idl
@@ -151,7 +151,8 @@ interface ArrayBinding : Node {
 };
 
 interface ObjectBinding : Node {
-  attribute (BindingProperty or BindingRest)[] properties;
+  attribute (BindingProperty)[] properties;
+  attribute BindingIdentifier? rest;
 };
 
 interface BindingProperty : Node { };
@@ -166,11 +167,6 @@ interface BindingPropertyIdentifier : BindingProperty {
 interface BindingPropertyProperty : BindingProperty {
   attribute PropertyName name;
   attribute (Binding or BindingWithDefault) binding;
-};
-
-// `...BindingRest`
-interface BindingRest : Node {
-  attribute IdentifierExpression argument;
 };
 
 // This interface represents the case where the initializer is present in `AssignmentElement :: DestructuringAssignmentTarget Initializer_opt`.
@@ -189,6 +185,7 @@ interface ArrayAssignmentTarget : Node {
 // `ObjectAssignmentPattern`
 interface ObjectAssignmentTarget : Node {
   attribute AssignmentTargetProperty[] properties;
+  attribute SimpleAssignmentTarget? rest;
 };
 
 // `AssignmentProperty`


### PR DESCRIPTION
re: #119

This is PR to discuss the AST for the "Rest/Spread Properties" proposal currently at Stage 3

```js
let { ...BindingRest } = { ...SpreadElement };
```

Changes:
- ~~Introduced new `BindingRest` node which accepts an `Expression` as `expression`~~
- ~~Added `BindingRest` to the `properties` of `ObjectBinding`~~
- ~~Added `SpreadElement` to the `properties` of `ObjectExpression`~~
- Added optional `rest` property to `ObjectBinding` which accepts a `BindingIdentifier`
- Added optional `rest` property to `ObjectAssignmentTarget` which accepts a `SimpleAssignmentTarget`
