### PR TITLE
Proposal: Async Iteration

### DIFF
--- a/attribute-order.conf
+++ b/attribute-order.conf
@@ -175,6 +175,7 @@ items
 rest
 
 [ForOfStatement]
+isAsync
 left
 right
 body

--- a/spec.idl
+++ b/spec.idl
@@ -541,6 +541,8 @@ interface ForInStatement : IterationStatement {
 
 // `for ( LeftHandSideExpression of Expression ) Statement`, `for ( var ForBinding of Expression ) Statement`, `for ( ForDeclaration of Expression ) Statement`
 interface ForOfStatement : IterationStatement {
+  // True for `AsyncForOfStatement`, false otherwise.
+  attribute boolean isAsync;
   // The expression or declaration before `of`.
   attribute (VariableDeclaration or AssignmentTarget) left;
   // The expression after `of`.


### PR DESCRIPTION
re: #119

This is PR to discuss the AST for the "Async Iteration" proposal currently at Stage 3

```js
async function method() {
  for await (let item of items) {
    // ...
  }
}
```

Changes:
- Added a `boolean` property `isAsync` to `ForOfStatement`

Alternatives:
- Create a new `AsyncForOfStatement` node extending `ForOfStatement`

Notes:

I chose to use `isAsync` because that seemed most consistent. Since the link between `AwaitExpression` and `Function.isAsync` is currently implicit in Shift, it didn't seem worthwhile to add a new node which would require a lot of reworking to make it only valid within a new `AsyncFunction` node.

It'd be equally complex for a `AsyncForOfStatement` as you'd need create async nodes for all the statement types which have a block. i.e. `AsyncIfStatement`
