### PR TITLE
Proposal: Dynamic Import

### DIFF
--- a/attribute-order.conf
+++ b/attribute-order.conf
@@ -229,6 +229,9 @@ moduleSpecifier
 [ImportDeclaration]
 moduleSpecifier
 
+[ImportExpression]
+argument
+
 [ImportNamespace]
 defaultBinding
 namespaceBinding

--- a/spec.idl
+++ b/spec.idl
@@ -253,6 +253,11 @@ interface ImportSpecifier : Node {
   attribute BindingIdentifier binding;
 };
 
+// `import()`
+interface ImportExpression : Expression {
+  attribute Expression argument;
+};
+
 // `export * FromClause;`
 interface ExportAllFrom : ExportDeclaration {
   attribute string moduleSpecifier;


### PR DESCRIPTION
re: #119

This is PR to discuss the AST for the "Dynamic Import" proposal currently at Stage 3

```js
import("module")
```

Changes:
- Added a `ImportExpression` node with a `argument` property which is an `Expression`

Alternatives:
- Create a new node that can be passed to `CallExpression` (Babylon does this)

Notes:

I figured it was best not to use CallExpression because dynamic imports can only have exactly one argument.

Taking into consideration the `import.meta` proposal (and `function.sent` at the same time), I think it'd be best to add a new `MetaPropertyExpression` node type that either accepts two strings or is extended with `ImportMetaPropertyExpression` and `FunctionMetaPropertyExpression`. Either way I don't think it should reuse the `ImportExpression` node defined here.