### PR TITLE
Proposal: function.sent

### DIFF
--- a/attribute-order.conf
+++ b/attribute-order.conf
@@ -209,6 +209,9 @@ name
 params
 body
 
+[FunctionMetaPropertyExpression]
+property
+
 [Getter]
 name
 body

--- a/attribute-order.conf
+++ b/attribute-order.conf
@@ -209,7 +209,7 @@ name
 params
 body
 
-[FunctionMetaPropertyExpression]
+[FunctionPropertyExpression]
 property
 
 [Getter]

--- a/spec.idl
+++ b/spec.idl
@@ -52,7 +52,7 @@ enum BinaryOperator {
 enum UnaryOperator { "+", "-", "!", "~", "typeof", "void", "delete" };
 enum UpdateOperator { "++", "--" };
 
-enum FunctionMetaProperties { "sent" };
+enum FunctionProperty { "sent" };
 
 // `FunctionExpression`, `FunctionDeclaration`, `GeneratorExpression`, `GeneratorDeclaration`, `AsyncFunctionExpression`, `AsyncFunctionDeclaration`
 interface Function {
@@ -506,9 +506,9 @@ interface AwaitExpression : Expression {
   attribute Expression expression;
 };
 
-// FunctionMetaPropertyExpression :: function . MetaProperty
-interface FunctionMetaPropertyExpression : Expression {
-  attribute FunctionMetaProperties property;
+// FunctionPropertyExpression :: function . FunctionProperty
+interface FunctionPropertyExpression : Expression {
+  attribute FunctionProperty property;
 };
 
 // other statements

--- a/spec.idl
+++ b/spec.idl
@@ -52,6 +52,8 @@ enum BinaryOperator {
 enum UnaryOperator { "+", "-", "!", "~", "typeof", "void", "delete" };
 enum UpdateOperator { "++", "--" };
 
+enum FunctionMetaProperties { "sent" };
+
 // `FunctionExpression`, `FunctionDeclaration`, `GeneratorExpression`, `GeneratorDeclaration`, `AsyncFunctionExpression`, `AsyncFunctionDeclaration`
 interface Function {
   // True for `AsyncFunctionExpression` and `AsyncFunctionDeclaration`, false otherwise.
@@ -504,6 +506,10 @@ interface AwaitExpression : Expression {
   attribute Expression expression;
 };
 
+// FunctionMetaPropertyExpression :: function . MetaProperty
+interface FunctionMetaPropertyExpression : Expression {
+  attribute FunctionMetaProperties property;
+};
 
 // other statements
 


### PR DESCRIPTION
re: #119

This is PR to discuss the AST for the "function.sent" proposal currently at Stage 2

```js
function *method() {
  function.sent
}
```

Changes:
- ~~Added a `FunctionMetaPropertyExpression` node with a `property` property which is an `FunctionMetaProperties`~~
- Added a `FunctionPropertyExpression` node with a `property` property which is an `FunctionMetaProperty`

Alternatives:
- Generic `MetaPropertyExpression` node that has both `object` and `property` properties which are just strings
- MemberExpression with two identifiers

Notes:

I figure this and `import.meta` could both extend the same `MetaPropertyExpression` interface, which can likely be added to the existing spec since it was defined as part of es2015. It just wouldn't be used for anything yet.

`import.meta` PR: #126