### PR TITLE
Proposal: import.meta

### DIFF
--- a/attribute-order.conf
+++ b/attribute-order.conf
@@ -229,13 +229,13 @@ moduleSpecifier
 [ImportDeclaration]
 moduleSpecifier
 
-[ImportMetaPropertyExpression]
-property
-
 [ImportNamespace]
 defaultBinding
 namespaceBinding
 moduleSpecifier
+
+[ImportPropertyExpression]
+property
 
 [ImportSpecifier]
 name

--- a/attribute-order.conf
+++ b/attribute-order.conf
@@ -229,6 +229,9 @@ moduleSpecifier
 [ImportDeclaration]
 moduleSpecifier
 
+[ImportMetaPropertyExpression]
+property
+
 [ImportNamespace]
 defaultBinding
 namespaceBinding

--- a/spec.idl
+++ b/spec.idl
@@ -52,6 +52,8 @@ enum BinaryOperator {
 enum UnaryOperator { "+", "-", "!", "~", "typeof", "void", "delete" };
 enum UpdateOperator { "++", "--" };
 
+enum ImportMetaProperties { "meta" };
+
 // `FunctionExpression`, `FunctionDeclaration`, `GeneratorExpression`, `GeneratorDeclaration`, `AsyncFunctionExpression`, `AsyncFunctionDeclaration`
 interface Function {
   // True for `AsyncFunctionExpression` and `AsyncFunctionDeclaration`, false otherwise.
@@ -504,6 +506,9 @@ interface AwaitExpression : Expression {
   attribute Expression expression;
 };
 
+interface ImportMetaPropertyExpression : Expression {
+  attribute ImportMetaProperties property;
+};
 
 // other statements
 

--- a/spec.idl
+++ b/spec.idl
@@ -52,7 +52,7 @@ enum BinaryOperator {
 enum UnaryOperator { "+", "-", "!", "~", "typeof", "void", "delete" };
 enum UpdateOperator { "++", "--" };
 
-enum ImportMetaProperties { "meta" };
+enum ImportProperty { "meta" };
 
 // `FunctionExpression`, `FunctionDeclaration`, `GeneratorExpression`, `GeneratorDeclaration`, `AsyncFunctionExpression`, `AsyncFunctionDeclaration`
 interface Function {
@@ -506,8 +506,9 @@ interface AwaitExpression : Expression {
   attribute Expression expression;
 };
 
-interface ImportMetaPropertyExpression : Expression {
-  attribute ImportMetaProperties property;
+// ImportPropertyExpression :: import . ImportProperty
+interface ImportPropertyExpression : Expression {
+  attribute ImportProperty property;
 };
 
 // other statements


### PR DESCRIPTION
re: #119

This is PR to discuss the AST for the "import.meta" proposal currently at Stage 2

```js
import.meta
```

Changes:
- Added a `ImportMetaProperties` enum with valid properties for `import.{property}`
- Added a `ImportMetaPropertyExpression` node with a `property` property which is an `ImportMetaProperties`

Alternatives:
- Generic `MetaPropertyExpression` node that has both `object` and `property` properties which are just strings
- MemberExpression with two identifiers

Notes:

I figure this and `function.sent` could both extend the same `MetaPropertyExpression` interface, which can likely be added to the existing spec since it was defined as part of es2015. It just wouldn't be used for anything yet.

`function.sent` PR: #125