### PR TITLE
Proposal: BigInt

### DIFF
--- a/attribute-order.conf
+++ b/attribute-order.conf
@@ -245,6 +245,9 @@ body
 label
 body
 
+[LiteralBigIntExpression]
+value
+
 [LiteralBooleanExpression]
 value
 

--- a/spec.idl
+++ b/spec.idl
@@ -357,6 +357,11 @@ interface LiteralNumericExpression : Expression {
   attribute double value;
 };
 
+// `BigIntLiteral`
+interface LiteralBigIntExpression : Expression {
+  attribute string value;
+};
+
 // `RegularExpressionLiteral`
 interface LiteralRegExpExpression : Expression {
   attribute string pattern;


### PR DESCRIPTION
re: #119

This is PR to discuss the AST for the "BigInt" proposal currently at Stage 2

```js
0xFFF123n
```

Changes:
- Added a `LiteralBigIntExpression ` node with a `value` property which is a `string`

Notes:

Babylon adds `extra.raw` and `extra.rawValue` properties to match the `StringLiteral` type

```js
extra: {
  rawValue: "0xFFF123",
  raw: "0xFFF123n"
}
```

Shift has no equivalent so I've used just `value` which I assume will be `0xFFF123` for the the big int `0xFFF123n`.