### PR TITLE
Proposal: export default from

### DIFF
--- a/attribute-order.conf
+++ b/attribute-order.conf
@@ -146,6 +146,7 @@ moduleSpecifier
 body
 
 [ExportFrom]
+defaultBinding
 namedExports
 moduleSpecifier
 

--- a/spec.idl
+++ b/spec.idl
@@ -260,6 +260,8 @@ interface ExportAllFrom : ExportDeclaration {
 
 // `export ExportClause FromClause;`
 interface ExportFrom : ExportDeclaration {
+  // `ExportedDefaultBinding`, if present.
+  attribute BindingIdentifier? defaultBinding;
   attribute ExportFromSpecifier[] namedExports;
   attribute string moduleSpecifier;
 };


### PR DESCRIPTION
re: #119

This is PR to discuss the AST for the "export default from" proposal currently at Stage 1

```js
export default from "module";
export namedDefault from "module";
export default, {named} from "module";
export namedDefault, {named} from "module";
```

Changes:
- Added an optional `defaultBinding` property to the `ExportFrom ` node which is a `string`

Notes:

This mirrors the optional [`Import.defaultBinding`](https://github.com/shapesecurity/shift-spec/blob/5ec1b2d48b3d2458b9d1aa435933c1ce6cc549c3/spec.idl#L239) property. The only difference is that `defaultBinding` accepts `"default"` here where `Import.defaultBinding` would not. That didn't seem important to distinguish so I've left it as it is here.