### PR TITLE
Proposal: export * as ns from

### DIFF
--- a/attribute-order.conf
+++ b/attribute-order.conf
@@ -160,6 +160,14 @@ namedExports
 name
 exportedName
 
+[ExportNamespaceFrom]
+defaultBinding
+namespaceExport
+moduleSpecifier
+
+[ExportNamespaceFromSpecifier]
+exportedName
+
 [Expression]
 
 [ExpressionStatement]

--- a/spec.idl
+++ b/spec.idl
@@ -264,6 +264,14 @@ interface ExportFrom : ExportDeclaration {
   attribute string moduleSpecifier;
 };
 
+// `export ExportNamespaceClause FromClause;`
+interface ExportNamespaceFrom : ExportDeclaration {
+  // `ExportedDefaultBinding`, if present.
+  attribute BindingIdentifier? defaultBinding;
+  attribute ExportNamespaceFromSpecifier namespaceExport;
+  attribute string moduleSpecifier;
+};
+
 // `export ExportClause;`
 interface ExportLocals : ExportDeclaration {
   attribute ExportLocalSpecifier[] namedExports;
@@ -285,6 +293,12 @@ interface ExportFromSpecifier : Node {
   attribute IdentifierName name;
   // The second `IdentifierName` in `ExportSpecifier :: IdentifierName as IdentifierName`, if that is the production represented.
   attribute IdentifierName? exportedName;
+};
+
+// `ExportSpecifier`, as part of an `ExportFrom`.
+interface ExportNamespaceFromSpecifier : Node {
+  // The `IdentifierName` in `ExportNamespaceFromSpecifier :: * as IdentifierName`.
+  attribute IdentifierName exportedName;
 };
 
 // `ExportSpecifier`, as part of an `ExportLocals`.


### PR DESCRIPTION
re: #119

This is PR to discuss the AST for the "export * as ns from" proposal currently at Stage 1

```js
export * as ns from "module";
```

This also interacts with `export default from` in #128 so I've included changes that assume that proposal is also accepted.

```js
export default, * as ns from "module";
export namedDefault, * as ns from "module";
```

Changes:
- Added a `ExportNamespaceFromSpecifier` node which has a `exportedName` property that accepts a `IdentifierName`
- Added a `ExportNamespaceFrom` node which extends `ExportDeclaration` and accepts the properties:
  - `defaultBinding` which is an optional `BindingIdentifier` (should only exist if `export default from` proposal is accepted
  - `namespaceExport` which is an `ExportNamespaceFromSpecifier`
  - `moduleSpecifier` which is a string

Alternatives:
1. Make `ExportFromSpecifier.name` optional

Notes:

If Shift simply accepted a `ExportFromSpecifier` with an optional `name` property, there'd be a couple of issues:

1. Only three out of the four possible combinations would be supported:

- `ExportFromSpecifier { name }` - `export {name} from`
- `ExportFromSpecifier { name, exportedName }` - `export {name as exportedName} from`
- `ExportFromSpecifier { exportedName }` - `export * as exportedName from`
- `ExportFromSpecifier { }` - **Invalid**

2. ExportFrom accepts an array of ExportFromSpecifiers, however it can only have one if it is a namespace export.

