### PR TITLE
Proposal: Optional Chaining

### DIFF
--- a/attribute-order.conf
+++ b/attribute-order.conf
@@ -70,6 +70,7 @@ block
 label
 
 [CallExpression]
+isOptional
 callee
 arguments
 
@@ -105,6 +106,7 @@ object
 expression
 
 [ComputedMemberExpression]
+isOptional
 object
 expression
 
@@ -270,6 +272,7 @@ value
 object
 
 [MemberExpression]
+isOptional
 object
 
 [Method]
@@ -291,6 +294,7 @@ items
 name
 
 [NewExpression]
+isOptional
 callee
 arguments
 
@@ -338,6 +342,7 @@ object
 property
 
 [StaticMemberExpression]
+isOptional
 object
 property
 

--- a/spec.idl
+++ b/spec.idl
@@ -79,6 +79,7 @@ interface IterationStatement : Statement {
 interface Expression : Node { };
 // `MemberExpression`, `SuperProperty`
 interface MemberExpression : Expression {
+  attribute boolean isOptional;
   // The object whose property is being accessed.
   attribute (Expression or Super) _object;
 };
@@ -412,6 +413,7 @@ interface BinaryExpression : Expression {
 };
 
 interface CallExpression : Expression {
+  attribute boolean isOptional;
   attribute (Expression or Super) callee;
   attribute Arguments arguments;
 };
@@ -450,6 +452,7 @@ interface IdentifierExpression : Expression { };
 IdentifierExpression implements VariableReference;
 
 interface NewExpression : Expression {
+  attribute boolean isOptional;
   attribute Expression callee;
   attribute Arguments arguments;
 };


### PR DESCRIPTION
re: #119

This is PR to discuss the AST for the "Optional Chaining" proposal currently at Stage 1

```js
obj?.prop       // optional property access
obj?.[expr]     // optional property access
func?.(...args) // optional function or method call

a?.b = 42; // a == null ? undefined : a.b = 42;
```

Changes:
- Added a `isOptional` property to the `MemberExpression` node which is a boolean
- Added a `isOptional` property to the `CallExpression` node which is a boolean
- Added a `isOptional` property to the `NewExpression` node which is a boolean

Alternatives:
- Wrap `object` or `callee` in a new node type

Notes:

Since the changed behavior exists on property lookup and at call time it makes sense to make this properties on those operations. They are different operations so it doesn't make much sense to create a node for it.