### PR TITLE
Proposal: do expressions

### DIFF
--- a/attribute-order.conf
+++ b/attribute-order.conf
@@ -128,6 +128,9 @@ expression
 [Directive]
 rawValue
 
+[DoExpression]
+body
+
 [DoWhileStatement]
 body
 test

--- a/spec.idl
+++ b/spec.idl
@@ -506,7 +506,7 @@ interface AwaitExpression : Expression {
 
 // `DoExpression :: do BlockStatement`
 interface DoExpression : Expression {
-  attribute BlockStatement body;
+  attribute Block body;
 };
 
 // other statements

--- a/spec.idl
+++ b/spec.idl
@@ -504,6 +504,10 @@ interface AwaitExpression : Expression {
   attribute Expression expression;
 };
 
+// `DoExpression :: do BlockStatement`
+interface DoExpression : Expression {
+  attribute BlockStatement body;
+};
 
 // other statements
 


### PR DESCRIPTION
re: #119

This is PR to discuss the AST for the "Do Expressions" proposal currently at Stage 1

```js
let a = do {
  if (x > 10) {
    'big';
  } else {
    'small';
  }
};
```

Changes:
- Added a `DoExpression` node that extends `Expression` and has a property `body` which accepts a `BlockStatement`

Notes:

There is automatic return behavior that goes along with do expressions, but that didn't seem important to find a way to distinguish. Similar to how async-await is treated.