### PR TITLE
Proposal: Function Bind Operator

### DIFF
--- a/attribute-order.conf
+++ b/attribute-order.conf
@@ -43,6 +43,10 @@ left
 operator
 right
 
+[BindExpression]
+object
+callee
+
 [BindingIdentifier]
 name
 
@@ -59,6 +63,9 @@ binding
 [BindingWithDefault]
 binding
 init
+
+[BindMemberExpression]
+memberExpression
 
 [Block]
 statements

--- a/spec.idl
+++ b/spec.idl
@@ -504,6 +504,14 @@ interface AwaitExpression : Expression {
   attribute Expression expression;
 };
 
+interface BindExpression : Expression {
+  attribute Expression object;
+  attribute Expression callee;
+};
+
+interface BindMemberExpression : Expression {
+  attribute MemberExpression memberExpression;
+};
 
 // other statements
 


### PR DESCRIPTION
re: #119

This is PR to discuss the AST for the "Function Bind Operator" proposal currently at Stage 0

```js
obj::func
// is equivalent to:
func.bind(obj)

obj::func(val)
// is equivalent to:
func.call(obj, val)

::obj.func(val)
// is equivalent to:
func.call(obj, val)
```

Changes:
- Added a `BindExpression` node with the properties:
  - `object` that accepts an `Expression`
  - `callee` that accepts an Expression`
- Added a `BindMemberExpression` node with the properties:
  - `memberExpression` that accepts a `MemberExpression`

Alternatives:
- Reuse the same `BindExpression` node and make `object` optional (Babylon does this)

Notes:

I thought it was best to use two separate node types, since the form `::obj.prop` only accepts a `MemberExpression` on the right-hand side and will otherwise be a syntax error. Where the form `obj::prop` can have any expression on the right-hand side.

I really hate all the names here, so I'm open to suggestions.