### PR TITLE
Version 2017.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-spec-idl",
-  "version": "2017.0.0-pre",
+  "version": "2017.0.0",
   "description": "Shift AST specification IDL files",
   "author": "Shape Security",
   "homepage": "https://github.com/shapesecurity/shift-spec",


### PR DESCRIPTION
Time to release this.

I just checked the spec's commit log again and confirmed there's nothing except async functions requiring changes from the 2016 version of the spec, and we [have support for those](https://github.com/shapesecurity/shift-spec/pull/116).